### PR TITLE
Update references from sp to full.sp in .get_bigS in utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -214,7 +214,7 @@
    if(num_smooth_terms == 0)
       return(bigS)
    
-   num_Smatrices_per_smooth <- lapply(fit_gam$smooth, function(x) length(x$S)) # The sum of this should equal length(fit_gam$sp), or equivalently fit_gam$smooth[[num_smooth_terms]]$last.sp
+   num_Smatrices_per_smooth <- lapply(fit_gam$smooth, function(x) length(x$S)) # The sum of this should equal length(fit_gam$full.sp), or equivalently fit_gam$smooth[[num_smooth_terms]]$last.sp
    sp_index <- split(1:fit_gam$smooth[[num_smooth_terms]]$last.sp, rep(1:num_smooth_terms, num_Smatrices_per_smooth)) # Because fs, te, and ti smooths have multiple S and smoothing parameters, then this tells you how many and indexes the S/sp's within each smooth term. This is very similar to extracting first.sp and last.sp from each smooth
    rm(num_Smatrices_per_smooth)
    #num_smooth_cols <- sum(sapply(fit_gam$smooth, function(x) x$df)) # According to ?smooth.construct, this is the degrees of freedom associated with this term when unpenalized and unconstrained
@@ -222,10 +222,10 @@
    num_parametric_cols <- num_X - num_smooth_cols
 
    subS <- lapply(1:num_smooth_terms, function(j) {
-      out <- fit_gam$sp[sp_index[[j]][1]] * fit_gam$smooth[[j]]$S[[1]]
+      out <- fit_gam$full.sp[sp_index[[j]][1]] * fit_gam$smooth[[j]]$S[[1]]
       if(length(sp_index[[j]]) > 1) { # To deal with smooths that have multiple S matrices and smoothing parameters
          for(l0 in 2:length(sp_index[[j]]))
-            out <- out + fit_gam$sp[sp_index[[j]][l0]] * fit_gam$smooth[[j]]$S[[l0]]
+            out <- out + fit_gam$full.sp[sp_index[[j]][l0]] * fit_gam$smooth[[j]]$S[[l0]]
           }
       
       if(any(!is.finite(out))) {


### PR DESCRIPTION
Use fit_gam$full.sp instead of fit_gam$sp so indexing remains correct when any sps are user-fixed (e.g., te/ti/fs/ad smooths or custom multi-penalty smooths with sp=c(-1, x) style specification).  

## Bug

`.get_bigS` (R/utils.R, lines 225 and 228) indexes `fit_gam$sp` to build
the penalty matrix for V_β construction. This works correctly only when
all smoothing parameters are estimated by REML. When any sp is
user-fixed — e.g., `s(x, bs="ts", sp=c(-1, 0.5))`, or smooths like te/ti/fs/ad
where some marginal sps can be fixed — `fit_gam$sp` excludes the fixed sps,
so its length is less than `last.sp`. The indexing then either:

1. Picks up the wrong smooth's estimated sp for some smooths, or
2. Returns NA when indexing past the end of `fit_gam$sp`, which is then
   zeroed by the safety check, eliminating the penalty contribution for
   those smooths.

Both cases distort `covar_components$topleft` and downstream uncertainty
quantification (smooth CIs, parametric SEs, corX/corB results).

## Fix

Use `fit_gam$full.sp` (always length `last.sp`, includes both estimated
and fixed sps in the correct order) instead of `fit_gam$sp`.

## How to reproduce

Fit any CBFM model where a smooth has multiple S matrices and at least
one sp is user-fixed. Inspect `covar_components$topleft` for blocks
corresponding to different smooths — trace values will vary by orders
of magnitude in patterns inconsistent with the data and the documented
formula at line 3803.

## Scope

The fix only changes V_β computation post-fit. The converged betas and
basis effects are unaffected (the bug only touches `.get_bigS`, whose
output is used solely in post-hoc covariance assembly at lines 3739,
3749, 3783, 3791 of CBFM.R).

Verified empirically: applying the fix via `assignInNamespace` and
refitting produces V_β block traces that are consistent across covariates
and in the expected magnitude range, while reproducing identical
estimated coefficients to the original fit.